### PR TITLE
Fix filepicker and directory picker deadlock issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+.idea

--- a/src/ScriptRunner/ScriptRunner.GUI/Views/DirectoryPicker.axaml.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Views/DirectoryPicker.axaml.cs
@@ -33,7 +33,7 @@ namespace ScriptRunner.GUI.Views
             set => SetValue(DirPathProperty, value);
         }
 
-        private void ChangeDirClick(object? sender, RoutedEventArgs e)
+        private async void ChangeDirClick(object? sender, RoutedEventArgs e)
         {
             if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
@@ -45,7 +45,7 @@ namespace ScriptRunner.GUI.Views
                     dialog.Directory = DirPath;
                 }
 
-                if (dialog.ShowAsync(sourceWindow).GetAwaiter().GetResult() is { } selectedDirPath)
+                if (await dialog.ShowAsync(sourceWindow) is { } selectedDirPath)
                 {
                     DirPath = selectedDirPath;
                     OnDirectoryPicked?.Invoke(this, new FilePickedArgs(selectedDirPath));

--- a/src/ScriptRunner/ScriptRunner.GUI/Views/FilePicker.axaml.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Views/FilePicker.axaml.cs
@@ -32,7 +32,7 @@ namespace ScriptRunner.GUI.Views
             set => SetValue(FilePathProperty, value);
         }
 
-        private void ChangeFileClick(object? sender, RoutedEventArgs e)
+        private async void ChangeFileClick(object? sender, RoutedEventArgs e)
         {
             if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
@@ -47,8 +47,8 @@ namespace ScriptRunner.GUI.Views
                 }
                 
                 dialog.AllowMultiple = false;
-                
-                var result = dialog.ShowAsync(sourceWindow).GetAwaiter().GetResult();
+
+                var result = await dialog.ShowAsync(sourceWindow);
                 if (result?.FirstOrDefault() is { } file)
                 {
                     FilePath = file;


### PR DESCRIPTION
If you try to use file, or directory picker on MacOS it immediately hangs the app with a deadlock. This PR fixes this issue by replacing the blocking call with the async one. 