### PR TITLE
Add Vault support for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 .idea
+.DS_Store

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/IDataProtector.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/IDataProtector.cs
@@ -1,0 +1,7 @@
+namespace ScriptRunner.GUI.Infrastructure.DataProtection;
+
+public interface IDataProtector
+{
+    public byte[] Protect(byte[] data);
+    public byte[] Unprotect(byte[] data);
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/MacDataProtector.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/MacDataProtector.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace ScriptRunner.GUI.Infrastructure.DataProtection;
+
+internal class MacDataProtector : IDataProtector
+{
+    private readonly Microsoft.AspNetCore.DataProtection.IDataProtector _dataProtector;
+
+    public MacDataProtector(IDataProtectionProvider dataProtectionProvider)
+    {
+        _dataProtector = dataProtectionProvider.CreateProtector("MacOsEncryption");
+    }
+
+    public byte[] Protect(byte[] data)
+    {
+        return _dataProtector.Protect(data);
+    }
+
+    public byte[] Unprotect(byte[] data)
+    {
+        return _dataProtector.Unprotect(data);
+    }
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/NullDataProtector.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/NullDataProtector.cs
@@ -1,0 +1,14 @@
+namespace ScriptRunner.GUI.Infrastructure.DataProtection;
+
+internal class NullDataProtector : IDataProtector
+{
+    public byte[] Protect(byte[] data)
+    {
+        return data;
+    }
+
+    public byte[] Unprotect(byte[] data)
+    {
+        return data;
+    }
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/WindowsDataProtector.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtection/WindowsDataProtector.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ScriptRunner.GUI.Infrastructure.DataProtection;
+
+internal class WindowsDataProtector : IDataProtector
+{
+    private static readonly byte[] EntropyKey = Encoding.ASCII.GetBytes("80CD0C6D-74D3-4E6D-9E4F-ECA485E69FC7");
+
+    public byte[] Protect(byte[] userData)
+    {
+        return ProtectedData.Protect(userData, EntropyKey, DataProtectionScope.CurrentUser);
+    }
+
+    public byte[] Unprotect(byte[] encryptedData)
+    {
+        return ProtectedData.Unprotect(encryptedData, EntropyKey, DataProtectionScope.CurrentUser);
+    }
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtectionExtensions.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DataProtectionExtensions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ScriptRunner.GUI.Infrastructure;
+
+public static class DataProtectionExtensions
+{
+    public static void AddDataProtectionConfigured(this IServiceCollection services)
+    {
+        var dataProtectionKeysDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MacOsEncryption-Keys");
+        var dataProtectionCertificate = SetupDataProtectionCertificate();
+        services.AddDataProtection()
+            .PersistKeysToFileSystem(new DirectoryInfo(dataProtectionKeysDirectory))
+            .ProtectKeysWithCertificate(dataProtectionCertificate);
+    }
+    
+    private static X509Certificate2 SetupDataProtectionCertificate()
+    {
+        string subjectName = "Script Runner Data Protection Certificate";
+        using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadOnly);
+        var certificateCollection = store.Certificates.Find(X509FindType.FindBySubjectName, subjectName, validOnly: false);
+        if (certificateCollection.Count > 0)
+        {
+            return certificateCollection[0];
+        }
+
+        var certificate = CreateSelfSignedDataProtectionCertificate($"CN={subjectName}");
+        InstallCertificate(certificate);
+        return certificate;
+    }
+
+    private static X509Certificate2 CreateSelfSignedDataProtectionCertificate(string subjectName)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddYears(1));
+        return certificate;
+    }
+
+    static void InstallCertificate(X509Certificate2 certificate)
+    {
+        var rawData = certificate.Export(X509ContentType.Pkcs12, password: "abc");
+        using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadWrite);
+        store.Certificates.Import(rawData, password: "abc", keyStorageFlags: X509KeyStorageFlags.PersistKeySet);
+    }
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DependencyInjectionExtensions.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/DependencyInjectionExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Platform;
+using Microsoft.Extensions.DependencyInjection;
+using Splat.Microsoft.Extensions.DependencyInjection;
+
+namespace ScriptRunner.GUI.Infrastructure;
+
+public static class DependencyInjectionExtensions
+{
+    public static TAppBuilder UseMicrosoftDependencyInjection<TAppBuilder>(this TAppBuilder builder, Action<IServiceCollection, IRuntimePlatform> configure)
+        where TAppBuilder : AppBuilderBase<TAppBuilder>, new()
+    {
+        var serviceCollection = new ServiceCollection();
+        configure(serviceCollection, builder.RuntimePlatform);
+        serviceCollection.UseMicrosoftDependencyResolver();
+        return builder;
+    }
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/VaultProvider.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Infrastructure/VaultProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using ScriptRunner.GUI.Infrastructure.DataProtection;
+using ScriptRunner.GUI.Settings;
+using ScriptRunner.GUI.ViewModels;
+
+namespace ScriptRunner.GUI.Infrastructure;
+
+public class VaultProvider
+{
+    const string VaultFileName = "Vault.dat";
+
+    private readonly IDataProtector _dataProtector;
+
+    public VaultProvider(IDataProtector dataProtector)
+    {
+        _dataProtector = dataProtector;
+    }
+
+    public IReadOnlyList<VaultEntry> ReadFromVault()
+    {
+        var vaultPath = AppSettingsService.GetSettingsPathFor(VaultFileName);
+        if (File.Exists(vaultPath))
+        {
+            var encryptedData = File.ReadAllBytes(vaultPath);
+
+            try
+            {
+                var data = _dataProtector.Unprotect(encryptedData);
+                return JsonSerializer.Deserialize<List<VaultEntry>>(data) ?? new List<VaultEntry>();
+            }
+            catch (Exception e)
+            {
+                //TODO: Invalid key 
+                Console.WriteLine(e);
+                throw;
+            }
+        }
+
+        return Array.Empty<VaultEntry>();
+    }
+
+    public void UpdateVault(List<VaultEntry> entries)
+    {
+        var vaultPath = AppSettingsService.GetSettingsPathFor(VaultFileName);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(entries);
+        var protectedBytes = _dataProtector.Protect(bytes);
+        File.WriteAllBytes(vaultPath, protectedBytes);
+    }
+}

--- a/src/ScriptRunner/ScriptRunner.GUI/ParamsPanelFactory.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/ParamsPanelFactory.cs
@@ -9,6 +9,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
+using ScriptRunner.GUI.Infrastructure;
 using ScriptRunner.GUI.ScriptConfigs;
 using ScriptRunner.GUI.Settings;
 using ScriptRunner.GUI.ViewModels;
@@ -18,11 +19,18 @@ namespace ScriptRunner.GUI;
 
 public class ParamsPanelFactory
 {
+    private readonly VaultProvider _vaultProvider;
+
+    public ParamsPanelFactory(VaultProvider vaultProvider)
+    {
+        _vaultProvider = vaultProvider;
+    }
+    
     public ParamsPanel Create(ScriptConfig action, Dictionary<string, string> values)
     {
         var paramsPanel = new StackPanel
         {
-            Classes = new Classes("paramsPanel"),
+            Classes = new Classes("paramsPanel")
         };
 
         var controlRecords = new List<IControlRecord>();
@@ -57,7 +65,7 @@ public class ParamsPanelFactory
         };
     }
 
-    private static IControlRecord CreateControlRecord(ScriptParam p, string? value, int index,
+    private IControlRecord CreateControlRecord(ScriptParam p, string? value, int index,
         ScriptConfig scriptConfig, List<VaultBinding> secretBindings)
     {
         switch (p.Prompt)
@@ -83,7 +91,7 @@ public class ParamsPanelFactory
 
                 if (secretBindings.FirstOrDefault(x => x.ActionName == scriptConfig.Name && x.ParameterName == p.Name) is { } binding)
                 {
-                    var vaultEntries = VaultProvider.ReadFromVault();
+                    var vaultEntries = _vaultProvider.ReadFromVault();
                     if (vaultEntries.FirstOrDefault(x => x.Name == binding.VaultKey) is { } vaultEntry)
                     {
                         passwordBox.VaultKey = vaultEntry.Name;

--- a/src/ScriptRunner/ScriptRunner.GUI/Program.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Program.cs
@@ -1,8 +1,15 @@
 using Avalonia;
 using Avalonia.ReactiveUI;
 using System;
+using Avalonia.Platform;
+using Microsoft.Extensions.DependencyInjection;
 using Projektanker.Icons.Avalonia;
 using Projektanker.Icons.Avalonia.FontAwesome;
+using ScriptRunner.GUI.Infrastructure;
+using ScriptRunner.GUI.Infrastructure.DataProtection;
+using ScriptRunner.GUI.ViewModels;
+using ScriptRunner.GUI.Views;
+using IDataProtector = ScriptRunner.GUI.Infrastructure.DataProtection.IDataProtector;
 
 namespace ScriptRunner.GUI;
 
@@ -16,11 +23,36 @@ internal class Program
         .StartWithClassicDesktopLifetime(args);
 
     // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
-            .UseReactiveUI()
-            .UsePlatformDetect()
-            .WithIcons(container => container
-                .Register<FontAwesomeIconProvider>())
-            .LogToTrace();
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
+        .UseReactiveUI()
+        .UsePlatformDetect()
+        .WithIcons(container => container
+            .Register<FontAwesomeIconProvider>())
+        .UseMicrosoftDependencyInjection(ConfigureServices)
+        .LogToTrace();
+
+    private static void ConfigureServices(IServiceCollection services, IRuntimePlatform runtimePlatform)
+    {
+        var runtimeInfo = runtimePlatform.GetRuntimeInfo();
+        if (runtimeInfo.OperatingSystem == OperatingSystemType.WinNT)
+        {
+            services.AddSingleton<IDataProtector, WindowsDataProtector>();
+        }
+        else if (runtimeInfo.OperatingSystem == OperatingSystemType.OSX)
+        {
+            services.AddDataProtectionConfigured();
+            services.AddSingleton<IDataProtector, MacDataProtector>();
+        }
+        else
+        {
+            services.AddSingleton<IDataProtector, NullDataProtector>();
+        }
+
+        services.AddSingleton<VaultProvider>();
+        services.AddSingleton<ParamsPanelFactory>();
+
+        services.AddTransient<VaultViewModel>();
+        services.AddTransient<VaultPickerViewModel>();
+        services.AddTransient<MainWindowViewModel>();
+    }
 }

--- a/src/ScriptRunner/ScriptRunner.GUI/ScriptRunner.GUI.csproj
+++ b/src/ScriptRunner/ScriptRunner.GUI/ScriptRunner.GUI.csproj
@@ -37,8 +37,10 @@
     <PackageReference Include="Avalonia.Xaml.Interactivity" Version="0.10.14" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="6.0.10" />
     <PackageReference Include="Projektanker.Icons.Avalonia" Version="4.4.0" />
     <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="4.4.0" />
+    <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="14.4.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>

--- a/src/ScriptRunner/ScriptRunner.GUI/Settings/LayoutSettings.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Settings/LayoutSettings.cs
@@ -1,4 +1,4 @@
-namespace ScriptRunner.GUI;
+namespace ScriptRunner.GUI.Settings;
 
 public class LayoutSettings
 {

--- a/src/ScriptRunner/ScriptRunner.GUI/Settings/ScriptRunnerAppSettings.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Settings/ScriptRunnerAppSettings.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
-using ScriptRunner.GUI.Settings;
 
-namespace ScriptRunner.GUI;
+namespace ScriptRunner.GUI.Settings;
 
 public class ScriptRunnerAppSettings
 {

--- a/src/ScriptRunner/ScriptRunner.GUI/ViewLocator.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/ViewLocator.cs
@@ -2,11 +2,19 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using ScriptRunner.GUI.ViewModels;
 using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ScriptRunner.GUI;
 
 public class ViewLocator : IDataTemplate
 {
+    private readonly IServiceProvider _serviceProvider;
+
+    public ViewLocator(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+    
     public IControl Build(object data)
     {
         var name = data.GetType().FullName!.Replace("ViewModel", "View");
@@ -14,7 +22,7 @@ public class ViewLocator : IDataTemplate
 
         if (type != null)
         {
-            return (Control)Activator.CreateInstance(type)!;
+            return (Control)ActivatorUtilities.CreateInstance(_serviceProvider, type);
         }
         else
         {

--- a/src/ScriptRunner/ScriptRunner.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/ViewModels/MainWindowViewModel.cs
@@ -19,6 +19,8 @@ namespace ScriptRunner.GUI.ViewModels;
 
 public class MainWindowViewModel : ReactiveObject
 {
+    private readonly ParamsPanelFactory _paramsPanelFactory;
+
     /// <summary>
     /// Contains panels with generated controls for every defined action
     /// </summary>
@@ -107,8 +109,9 @@ public class MainWindowViewModel : ReactiveObject
 
     public ObservableCollection<OutdatedRepositoryModel> OutOfDateConfigRepositories { get; } = new();
 
-    public MainWindowViewModel()
+    public MainWindowViewModel(ParamsPanelFactory paramsPanelFactory)
     {
+        _paramsPanelFactory = paramsPanelFactory;
         this.appUpdater = new GithubUpdater();
 
         this.WhenAnyValue(x => x.ActionFilter, x => x.Actions)
@@ -230,7 +233,7 @@ public class MainWindowViewModel : ReactiveObject
         //var actionPanel = new StackPanel();
 
         // Create IPanel with controls for all parameters
-        var paramsPanel = new ParamsPanelFactory().Create(action, parameterValues);
+        var paramsPanel = _paramsPanelFactory.Create(action, parameterValues);
 
         // Add panel with param controls to action panel
         //actionPanel.Children.Add(paramsPanel.Panel);

--- a/src/ScriptRunner/ScriptRunner.GUI/Views/MainWindow.axaml.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Views/MainWindow.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.ReactiveUI;
 using ReactiveUI;
 using ScriptRunner.GUI.Settings;
 using ScriptRunner.GUI.ViewModels;
+using Splat;
 using static System.Double;
 
 namespace ScriptRunner.GUI.Views;
@@ -16,7 +17,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
     public MainWindow()
     {
         InitializeComponent();
-        ViewModel = new MainWindowViewModel();
+        ViewModel = Locator.Current.GetService<MainWindowViewModel>();
         this.WhenActivated((disposableRegistration) =>
         {
             this.Bind(ViewModel, vm => vm.ActionFilter, v => v.ActionFilter.Text).DisposeWith(disposableRegistration);

--- a/src/ScriptRunner/ScriptRunner.GUI/Views/Vault.axaml.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Views/Vault.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using ScriptRunner.GUI.ViewModels;
+using Splat;
 
 namespace ScriptRunner.GUI.Views
 {
@@ -11,7 +12,8 @@ namespace ScriptRunner.GUI.Views
         public Vault()
         {
             InitializeComponent();
-            DataContext = this.ViewModel = new VaultViewModel();
+            
+            DataContext = this.ViewModel = Locator.Current.GetService<VaultViewModel>()!;
 #if DEBUG
             this.AttachDevTools();
 #endif

--- a/src/ScriptRunner/ScriptRunner.GUI/Views/VaultPicker.axaml.cs
+++ b/src/ScriptRunner/ScriptRunner.GUI/Views/VaultPicker.axaml.cs
@@ -3,12 +3,19 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using ReactiveUI;
+using ScriptRunner.GUI.Infrastructure;
 using ScriptRunner.GUI.ViewModels;
+using Splat;
 
 namespace ScriptRunner.GUI.Views
 {
-    public class VaultPickerViewModel:ViewModelBase
+    public class VaultPickerViewModel : ViewModelBase
     {
+        public VaultPickerViewModel(VaultProvider vaultProvider)
+        {
+            Entries = vaultProvider.ReadFromVault();
+        }
+        
         public IReadOnlyList<VaultEntry> Entries { get; set; }
 
         public VaultEntry? SelectedEntry
@@ -18,20 +25,14 @@ namespace ScriptRunner.GUI.Views
         }
 
         private VaultEntry? _selectedEntry;
-
-
-
     }
 
     public partial class VaultPicker : Window
     {
         public VaultPicker()
         {
+            DataContext = this.ViewModel = Locator.Current.GetService<VaultPickerViewModel>()!;
 
-            DataContext = this.ViewModel = new VaultPickerViewModel
-            {
-                Entries = VaultProvider.ReadFromVault()
-            };
             InitializeComponent();
 #if DEBUG
             this.AttachDevTools();


### PR DESCRIPTION
This PR adds Vault support for MacOS. The implementation is based [this](https://simplecodesoftware.com/articles/how-to-encrypt-data-on-macos-without-dpapi) article.